### PR TITLE
mmc: cd-gpio fix name scribbling

### DIFF
--- a/drivers/mmc/core/cd-gpio.c
+++ b/drivers/mmc/core/cd-gpio.c
@@ -19,8 +19,8 @@
 
 struct mmc_cd_gpio {
 	unsigned int gpio;
-	char label[0];
 	bool status;
+	char label[0];
 };
 
 static int mmc_cd_get_status(struct mmc_host *host)


### PR DESCRIPTION
The struct used to track the chip detect details was modified to
add a status field after the name.  Unfortunately, due to the way
that the cd-gpio driver handles this struct, this lead to scribbling
the first byte of the name.  Fix this by re-ordering the fields.

OPO-274

Change-Id: Icff6557345741a112b3a676f3b2b616cf4e954b2
(cherry picked from commit 66c92a3399015d653af8e856557344bde2f72848)
