### PR TITLE
ARM: dts: A0001: fix CABC setting for sharp panel

### DIFF
--- a/arch/arm/boot/dts/msm8974-oppo/dsi-panel-sharp-1080p-cmd.dtsi
+++ b/arch/arm/boot/dts/msm8974-oppo/dsi-panel-sharp-1080p-cmd.dtsi
@@ -89,9 +89,9 @@
 		qcom,mdss-dsi-reset-sequence = <1 5>, <0 10>, <1 10>;
 		cm,mdss-livedisplay-cabc-cmd = [
 			15 01 00 00 10 00 02 55 00];
-		cm,mdss-livedisplay-cabc-ui-value = <0x01>;
+		cm,mdss-livedisplay-cabc-ui-value = <0x02>;
 		cm,mdss-livedisplay-cabc-image-value = <0x02>;
-		cm,mdss-livedisplay-cabc-video-value = <0x03>;
+		cm,mdss-livedisplay-cabc-video-value = <0x02>;
 		cm,mdss-livedisplay-sre-weak-value = <0x50>;
 		cm,mdss-livedisplay-sre-medium-value = <0x60>;
 		cm,mdss-livedisplay-sre-strong-value = <0x70>;


### PR DESCRIPTION
Documentation shows only 0x02 is allowed for CABC on sharp panels.
Force all CABC modes to use this value.

This fixes an issue where flickering is observed at low backlight
brightness (10, 20, & 40 were verified).

OPO-409
Change-Id: I469cf3f18625707ee746a7a19e571fb169c6d808
Signed-off-by: Scott Mertz scott@cyngn.com
