### PR TITLE
Revert "msm8974-oppo: Optimize wakeup delay for JDI panel"

### DIFF
--- a/arch/arm/boot/dts/msm8974-oppo/dsi-panel-jdi-1080p-cmd.dtsi
+++ b/arch/arm/boot/dts/msm8974-oppo/dsi-panel-jdi-1080p-cmd.dtsi
@@ -53,14 +53,17 @@
 			29 01 00 00 01 00 07 b9 03 82 3c 10 3c 87
 			29 01 00 00 01 00 07 ba 03 78 64 10 64 b4
 			23 01 00 00 00 00 02 d6 01
+			23 01 00 00 01 00 02 b0 03
 			39 01 00 00 01 00 02 51 ff
 			15 01 00 00 01 00 02 53 2c
+			05 01 00 00 78 00 02 11 00
 			15 01 00 00 11 00 02 36 00
 			15 01 00 00 01 00 02 3a 77
-			39 01 00 00 01 00 03 44 00 00];
+			39 01 00 00 01 00 03 44 00 00
+			15 01 00 00 01 00 02 35 00];
 		qcom,mdss-dsi-off-command = [
-			05 01 00 00 11 00 02 28 00
-			05 01 00 00 32 00 02 10 00];
+			05 01 00 00 32 00 02 28 00
+			05 01 00 00 78 00 02 10 00];
 		qcom,mdss-dsi-calibration-command = [
 			23 01 00 00 01 00 02 b0 04
 			29 01 00 00 01 00 14 c8 01 0A FD 03 01 E8 00 00 03 FC F5 A1 00 00 01 FD 06 FC 00
@@ -91,7 +94,7 @@
 		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_wled";
 		qcom,mdss-dsi-reset-sequence = <1 5>, <0 10>, <1 10>;
 		cm,mdss-livedisplay-cabc-cmd = [
-			15 01 00 00 00 00 02 55 00];
+			15 01 00 00 10 00 02 55 00];
 		cm,mdss-livedisplay-cabc-ui-value = <0x01>;
 		cm,mdss-livedisplay-cabc-image-value = <0x02>;
 		cm,mdss-livedisplay-cabc-video-value = <0x03>;
@@ -100,9 +103,7 @@
 		cm,mdss-livedisplay-sre-strong-value = <0x70>;
 		cm,mdss-livedisplay-aco-value = <0x80>;
 		cm,mdss-livedisplay-post-cmd = [
-			23 01 00 00 01 00 02 b0 03
-			05 01 00 00 64 00 02 11 00
-			05 01 00 00 11 00 02 29 00];
+			05 01 00 00 10 00 02 29 00];
 		cm,mdss-livedisplay-color-enhance-on = [23 01 00 00 01 00 02 b0 04
 			29 01 00 00 10 00 21 ca 01
 			02 9a a4 b8 b4 b0 a4 08 28 05 87 b0 50 01 ff 05 f8 0c 0c 50 40 13 13 f0 08 10 10 3f 3f 3f 3f


### PR DESCRIPTION
This reverts commit 9401bd2eea0142f2de39ca163f4e61728b607aa8.

Display anomalies have been seen on some JDI panels after
introducing this change, such as the display contents being
offset and wrapping vertically.

Revert it for now. It looks correct, but since the latency
improvement it provides is relatively small and the timing
of the change correlates well with the reports of the issue,
it's the safest move.

Issue-Id: OPO-480
Change-Id: Ie413f707f0951834003c05ce7e4e598bfb618b92
Signed-off-by: Matt Wagantall mwagantall@cyngn.com
