### PR TITLE
qseecom: Fix issue related to retrieving pipe for PFE

### DIFF
--- a/drivers/misc/qseecom.c
+++ b/drivers/misc/qseecom.c
@@ -4405,7 +4405,7 @@ static int __devinit qseecom_probe(struct platform_device *pdev)
 		if (qseecom.support_pfe) {
 			if (of_property_read_u32((&pdev->dev)->of_node,
 				"qcom,file-encrypt-pipe-pair",
-				&qseecom.ce_info.disk_encrypt_pipe)) {
+				&qseecom.ce_info.file_encrypt_pipe)) {
 				pr_err("Fail to get PFE pipe information.\n");
 				rc = -EINVAL;
 				goto exit_destroy_ion_client;


### PR DESCRIPTION
Incorrect  parameter is overwritten when reading information
related to what pipe is used for PFE feature.

REF: OPO-461
Change-Id: I6747fa0b8b99d937475d3d12e2f9ed9a723f91bb
Signed-off-by: Mona Hossain mhossain@codeaurora.org
