### PR TITLE
input: synaptics_dsx: Send KEY_WAKEUP for double-tap event

### DIFF
--- a/drivers/input/touchscreen/synaptics_dsx_i2c.c
+++ b/drivers/input/touchscreen/synaptics_dsx_i2c.c
@@ -2403,7 +2403,7 @@ static unsigned char synaptics_rmi4_update_gesture2(unsigned char *gesture,
 		case SYNA_ONE_FINGER_DOUBLE_TAP:
 			gesturemode = DouTap;
 			if (atomic_read(&syna_rmi4_data->double_tap_enable))
-				keyvalue = KEY_POWER;
+				keyvalue = KEY_WAKEUP;
 			break;
 
 		case SYNA_ONE_FINGER_DIRECTION:
@@ -3816,7 +3816,7 @@ static void synaptics_rmi4_set_params(struct synaptics_rmi4_data *rmi4_data)
 	set_bit(KEY_MENU, rmi4_data->input_dev->keybit);
 	set_bit(KEY_HOMEPAGE, rmi4_data->input_dev->keybit);
 	set_bit(KEY_F3, rmi4_data->input_dev->keybit);
-	set_bit(KEY_POWER, rmi4_data->input_dev->keybit);
+	set_bit(KEY_WAKEUP, rmi4_data->input_dev->keybit);
 	set_bit(KEY_GESTURE_CIRCLE, rmi4_data->input_dev->keybit);
 	set_bit(KEY_GESTURE_SWIPE_DOWN, rmi4_data->input_dev->keybit);
 	set_bit(KEY_GESTURE_V, rmi4_data->input_dev->keybit);


### PR DESCRIPTION
KEY_POWER will confuse the system to end call.
If press power button to end call is enabled.
Use KEY_WAKEUP instead

CYNGNOS-2255
Change-Id: I22a5fb67ce4af960ffaf911846c10e534d787a86
